### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -19,6 +19,12 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-# Ignore dialyzer files
+# Ignore package tarball (built via "mix hex.build").
+pane-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Ignore dialyzer files.
 /priv/plts/*.plt
 /priv/plts/*.plt.hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## v0.4.1
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.4.1 - 2021-02-27
 
 **Fixed**
 
 - Include `:iex` in `:extra_applications` to remove compile warning.
 
-## v0.4.0
+## v0.4.0 - 2020-09-28
 
 **Changed**
 
@@ -16,18 +21,18 @@
 
 - Remove deprecated compile warnings.
 
-## v0.3.0
+## v0.3.0 - 2018-01-18
 
 - Support for (f)first and (l)last page
 
-## v0.2.0
+## v0.2.0 - 2018-01-03
 
 - Prompt to enable ANSI codes if disabled
 
-## v0.1.1
+## v0.1.1 - 2017-03-16
 
 - Fix: crash on invalid key command
 
-## v0.1.0
+## v0.1.0 - 2017-02-26
 
 - Initial release

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Codedge LLC (https://www.codedge.io/)
+Copyright (c) 2017 Codedge LLC (https://www.codedge.io/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[![Hex.pm](http://img.shields.io/hexpm/v/pane.svg)](https://hex.pm/packages/pane)
-[![Hex.pm](http://img.shields.io/hexpm/dt/pane.svg)](https://hex.pm/packages/pane)
-
 # Pane
+
+[![Module Version](https://img.shields.io/hexpm/v/pane.svg)](https://hex.pm/packages/pane)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/pane/)
+[![Total Download](https://img.shields.io/hexpm/dt/pane.svg)](https://hex.pm/packages/pane)
+[![License](https://img.shields.io/hexpm/l/pane.svg)](https://github.com/codedge-llc/pane/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/codedge-llc/pane.svg)](https://github.com/codedge-llc/pane/commits/master)
 
 Paginated data viewer for IEx. Written for [scribe](https://github.com/codedge-llc/scribe).
 Useful for inspecting large collections and deeply nested structs.
@@ -32,3 +35,10 @@ end
 - `f` - First page
 - `l` - Last page
 - `q` - Quit
+
+## Copyright and License
+
+Copyright (c) 2017 Codedge LLC (https://www.codedge.io/)
+
+This library is released under the MIT License. See the [LICENSE.md](./LICENSE.md) file
+for further details.

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule Pane.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/codedge-llc/pane"
   @version "0.4.1"
 
   def project do
@@ -8,7 +9,6 @@ defmodule Pane.Mixfile do
       app: :pane,
       build_embedded: Mix.env() == :prod,
       deps: deps(),
-      description: description(),
       dialyzer: dialyzer(),
       docs: docs(),
       elixir: "~> 1.5",
@@ -39,16 +39,18 @@ defmodule Pane.Mixfile do
     ]
   end
 
-  defp description do
-    """
-    Paginated printer for IEx
-    """
-  end
-
   defp docs do
     [
+      extras: [
+        "CHANGELOG.md",
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
       main: "readme",
-      extras: ["README.md"]
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      api_reference: false,
+      formatters: ["html"]
     ]
   end
 
@@ -60,10 +62,14 @@ defmodule Pane.Mixfile do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README*", "LICENSE*"],
+      description: "Paginated printer for IEx",
+      files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"],
       maintainers: ["Henry Popp"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/codedge-llc/pane"}
+      links: %{
+        "Changelog" => "https://hexdocs.pm/pane/changelog.html",
+        "GitHub" => "https://github.com/codedge-llc/pane"
+      }
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.